### PR TITLE
Example of fix to caching problem for main.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,17 @@ When changing Scala version you need to edit all these:
 
 # How to publish
 Can only be done with owner of the right credentials to fileadmin@cs: `sh publish.sh`
+
+## Force update cache for users
+When publishing a new version, change the version for JavaScript file main.js in src attribute of script tag in index.html on line 50. After this run `sh publish.sh`.
+
+Example: 
+
+Change 
+```html
+    <script type="text/javascript" src="https://fileadmin.cs.lth.se/pgk/kaptenalloc/main.js?version=1"></script>
+```
+to 
+```html
+    <script type="text/javascript" src="https://fileadmin.cs.lth.se/pgk/kaptenalloc/main.js?version=2"></script>
+```

--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
     <p> -->
 
     <!-- Include Scala.js compiled code -->
-    <script type="text/javascript" src="https://fileadmin.cs.lth.se/pgk/kaptenalloc/main.js"></script>
+    <script type="text/javascript" src="https://fileadmin.cs.lth.se/pgk/kaptenalloc/main.js?version=1"></script>
   </body>
 </html>
 


### PR DESCRIPTION
A simple hack fix for `main.js` being cached by browser when new times are published. See README change for info how to use. 

This fix uses query parameters to trick the browser into thinking a new file is fetched without needing a new filename. 