### PR TITLE
Change js output directory

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,8 @@ scalaVersion := "3.5.0"
 // This is an application with a main method
 scalaJSUseMainModuleInitializer := true
 
+Compile / fastLinkJS / scalaJSLinkerOutputDirectory := target.value / "js"
+
 libraryDependencies += ("org.scala-js" %%% "scalajs-dom" % "2.8.0")
 libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % "2.6.0"
 libraryDependencies += "io.github.cquiroz" %%% "scala-java-time-tzdb" % "2.6.0"

--- a/index-dev.html
+++ b/index-dev.html
@@ -40,7 +40,7 @@
   <body>
     index-dev.html
     <!-- Include Scala.js compiled code -->
-    <script type="text/javascript" src="./target/scala-3.5.0/kaptenalloc-web-fastopt/main.js"></script>
+    <script type="text/javascript" src="./target/js/main.js"></script>
   </body>
 </html>
 

--- a/publish.sh
+++ b/publish.sh
@@ -1,5 +1,4 @@
-VER=3.5.0
 scala run bump-version.sc
 sbt "clean;fastLinkJS"
-scp target/scala-$VER/kaptenalloc-web-fastopt/main.js $LUCATID@fileadmin.cs.lth.se:pgk/kaptenalloc/.
+scp target/js/main.js $LUCATID@fileadmin.cs.lth.se:pgk/kaptenalloc/.
 scp index.html $LUCATID@fileadmin.cs.lth.se:pgk/kaptenalloc/.


### PR DESCRIPTION
This changes the output directory of the `fastLinkJS` task to be `/target/js` instead of the previous `/target/scala-X.Y.Z/kaptenalloc-web-fastopt`.

Fixes: https://github.com/bjornregnell/kapten-alloc-web/issues/14