### PR TITLE
Check for TimeEdit - KaptenAlloc discrepancies on load, render UI element accordingly

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 This single-page client-only web app is available for download and execution in you browser here: https://fileadmin.cs.lth.se/pgk/kaptenalloc/
 There you can filter the schedule of this course: https://cs.lth.se/pgk
 
+The app also attempts to fetch the updated schedule from TimeEdit on page load in order to check for discrepancies between the saved data and TimeEdit. For this to work, the correct TimeEdit schedule URL must be set in `main.scala`, as shown here:
+```scala
+val timeEditScheduleUrl = "https://cloud.timeedit.net/lu/web/lth1/XXXXXXXXXXX.csv"
+```
+
 The static allocation data string is created by the closed source terminal app called [Kapten Alloc](http://www.nissepedia.com/index.php/Kapten_Haddocks_samlade_svordomar) that solves the hard problem of scheduling under constraints using the fantastic [Scala 3](https://scala-lang.org/) with [Scala JS](https://www.scala-js.org/doc/tutorial/basic/). It is built using [`sbt`](https://www.scala-sbt.org/).
 
 # How to bump Scala version

--- a/index-dev.html
+++ b/index-dev.html
@@ -35,6 +35,14 @@
         margin-right: 10px;
       }
       
+      #discrepancyPanel, #timeEditFailPanel {
+        display: flex;
+        flex-direction: column;
+        gap: 5px;
+        padding: 5px;
+        background-color: white;
+      }
+
     </style>
   </head>
   <body>

--- a/index.html
+++ b/index.html
@@ -35,6 +35,14 @@
         margin-right: 10px;
       }
 
+      #discrepancyPanel, #timeEditFailPanel {
+        display: flex;
+        flex-direction: column;
+        gap: 5px;
+        padding: 5px;
+        background-color: white;
+      }
+
     </style>
   </head>
   <body>

--- a/src/main/scala/main.scala
+++ b/src/main/scala/main.scala
@@ -9,15 +9,18 @@ import java.time.format.DateTimeFormatter
 import java.time.temporal.WeekFields
 import kaptenallocweb.timeEdit.TimeEdit
 
+val timeEditScheduleUrl = 
+  "https://cloud.timeedit.net/lu/web/lth1/ri19566250000YQQ28Z0507007y9Y4763gQ0g5X6Y65ZQ176.csv"
+
 @main def run: Unit = 
     document.addEventListener("DOMContentLoaded", (e: dom.Event) => 
       TimeEdit.fetchData(
-        onLoad = xhr => {
-          if xhr.status == 200 then
-            val diffs = TimeEdit.findDiscrepancies(timeEditData = xhr.responseText, kaptenAllocData = dataGeneratedFromKaptenAlloc)
-            if diffs.nonEmpty then addDiscrepancyPanel(diffs)
-          else addTimeEditFailPanel()
-        },
+        url = timeEditScheduleUrl,
+        onLoad = request => 
+          if request.status == 200 then
+            val diffs = TimeEdit.findDiscrepancies(timeEditData = request.responseText, kaptenAllocData = dataGeneratedFromKaptenAlloc)
+            if diffs.nonEmpty then addDiscrepancyPanel(diffs) else ()
+          else addTimeEditFailPanel(),
         onError = _ => 
           dom.console.warn("An error occured when fetching CSV data")
           addTimeEditFailPanel()
@@ -200,7 +203,7 @@ def addDiscrepancyPanel(discrepancies: Set[String]) =
 def addTimeEditFailPanel() = 
   val container = document.createElement("div").asInstanceOf[dom.html.Div]
   container.id = "timeEditFailPanel"
-  container.innerHTML = "Data från TimeEdit kunde ej hämtas - Dubbelkolla din sal där"
+  container.innerHTML = "TimeEdit i molnet svara inte just nu - KaptenAlloc kör med tidigare sparad data"
   document.body.prepend(container)
 
 // TODO: Give name to file based on if room, group or any field always are the same

--- a/src/main/scala/main.scala
+++ b/src/main/scala/main.scala
@@ -13,11 +13,14 @@ import kaptenallocweb.timeEdit.TimeEdit
     document.addEventListener("DOMContentLoaded", (e: dom.Event) => 
       TimeEdit.fetchData(
         onLoad = xhr => {
-          val diffs = TimeEdit.findDiscrepancies(timeEditData = xhr.responseText, kaptenAllocData = dataGeneratedFromKaptenAlloc)
-          dom.console.log(diffs.mkString(", "))
+          if xhr.status == 200 then
+            val diffs = TimeEdit.findDiscrepancies(timeEditData = xhr.responseText, kaptenAllocData = dataGeneratedFromKaptenAlloc)
+            if diffs.nonEmpty then addDiscrepancyPanel(diffs)
+          else addTimeEditFailPanel()
         },
         onError = _ => 
-          dom.console.log("An error occured when fetching CSV data")
+          dom.console.warn("An error occured when fetching CSV data")
+          addTimeEditFailPanel()
       )
       setupUI()
     )  
@@ -183,6 +186,22 @@ def setupUI(): Unit =
   filterText.appendChild(todayCheckBox)
   filterText.appendChild(todayLabel)
   document.body.appendChild(showText)
+
+def addDiscrepancyPanel(discrepancies: Set[String]) =
+  val container = document.createElement("div").asInstanceOf[dom.html.Div]
+  container.id = "discrepancyPanel"
+  discrepancies.foreach(discrepancy => 
+    val entrySpan = document.createElement("span").asInstanceOf[dom.html.Span]
+    entrySpan.innerHTML = discrepancy
+    container.appendChild(entrySpan)
+  )
+  document.body.prepend(container)
+
+def addTimeEditFailPanel() = 
+  val container = document.createElement("div").asInstanceOf[dom.html.Div]
+  container.id = "timeEditFailPanel"
+  container.innerHTML = "Data från TimeEdit kunde ej hämtas - Dubbelkolla din sal där"
+  document.body.prepend(container)
 
 // TODO: Give name to file based on if room, group or any field always are the same
 /** Creates file with given content, name and presents it as a download to the user */

--- a/src/main/scala/main.scala
+++ b/src/main/scala/main.scala
@@ -7,9 +7,20 @@ import org.scalajs.dom.document
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.time.temporal.WeekFields
+import kaptenallocweb.timeEdit.TimeEdit
 
 @main def run: Unit = 
-    document.addEventListener("DOMContentLoaded", (e: dom.Event) => setupUI())  
+    document.addEventListener("DOMContentLoaded", (e: dom.Event) => 
+      TimeEdit.fetchData(
+        onLoad = xhr => {
+          val diffs = TimeEdit.findDiscrepancies(timeEditData = xhr.responseText, kaptenAllocData = dataGeneratedFromKaptenAlloc)
+          dom.console.log(diffs.mkString(", "))
+        },
+        onError = _ => 
+          dom.console.log("An error occured when fetching CSV data")
+      )
+      setupUI()
+    )  
 
 extension (s: String)
   def containsAll(xs: Array[String], isCaseSensitive: Boolean = true): Boolean =

--- a/src/main/scala/tabby/Tabby.scala
+++ b/src/main/scala/tabby/Tabby.scala
@@ -1,0 +1,263 @@
+/*
+  This is a version of https://github.com/bjornregnell/tabby
+  in which Java dependencies (incompatible with ScalaJS)
+  have been stripped out to make it work inside kapten-alloc-web
+*/
+
+package kaptenallocweb.tabby
+
+object Grid:
+  type Row = Vector[String]
+  type Col = Vector[String]
+  type Matrix = Vector[Row]
+  type RowMap = Map[String, String]
+
+  val defaultDelim = '\t'
+  val defaultEnc = "UTF-8"
+  val iso8859Enc = "ISO-8859-1"
+  val defaultHeadingShowSep = '-'
+  val defaultColShowSep = '|'
+
+  extension (text: String)
+    def stripQuotesIfNoDelim(delim: Char = defaultDelim): String =
+      if text.size >= 2 && text.head == '"' && text.last == '"' && !text
+          .contains(delim)
+      then text.substring(1, text.length - 1)
+      else text
+
+    def splitUnquoted(delim: Char = defaultDelim): Vector[String] =
+      var start = 0
+      var isInsideQuotes = false
+      var i = 0
+      val result = scala.collection.mutable.ArrayBuffer.empty[String]
+      while i < text.length do
+        if text.charAt(i) == '"' then isInsideQuotes = !isInsideQuotes // toggle
+        else if text.charAt(i) == delim && !isInsideQuotes then
+          result += text.substring(start, i)
+          start = i + 1
+        i += 1
+      result += text.substring(start) // add last
+      result.map(_.stripQuotesIfNoDelim(delim)).toVector // remove unwanted ""
+
+  def fromLines(lines: Vector[String], delim: Char = defaultDelim): Grid =
+    val headings = lines(0).splitUnquoted(delim).toVector
+    val data = lines
+      .drop(1)
+      .map(
+        _.splitUnquoted(delim).toVector
+          .take(headings.length)
+          .padTo(headings.length, "")
+      )
+    Grid(headings, data)
+
+  val empty: Grid = Grid(Vector(), Vector())
+
+  def apply(headings: String*)(values: Any*): Grid =
+    val n = headings.length
+    val extra = values.length % n
+    val missing = if extra == 0 then 0 else n - extra
+    val strings = values.map(_.toString)
+    val padded =
+      if missing == 0 then strings
+      else strings.padTo(strings.length + missing, "")
+    val data = padded.map(_.toString).sliding(n, n).map(_.toVector)
+    Grid(headings.toVector, data.toVector)
+
+case class Grid(headings: Grid.Row, data: Grid.Matrix):
+  import Grid._
+
+  assert(
+    headings == headings.distinct,
+    s"headings contains duplicates: $headings"
+  )
+  assert(
+    data.map(_.size).forall(_ == headings.size),
+    s"all rows must match headings size"
+  )
+
+  lazy val dim = (data.size, headings.size)
+  lazy val (nRows, nCols) = dim
+
+  lazy val colIndex: Map[String, Int] = headings.zipWithIndex.toMap
+  private def mkRowMap(row: Int): RowMap =
+    headings.map(h => (h, apply(row)(h))).toMap
+  lazy val rowMap: Vector[RowMap] = data.indices.toVector.map(mkRowMap)
+
+  def apply(row: Int)(colName: String): String = data(row)(colIndex(colName))
+  def apply(colName: String): Col = data.map(row => row(colIndex(colName)))
+  def apply(row: Int, col: Int): String = data(row)(col)
+
+  def get(row: Int)(colName: String): Option[String] =
+    data.lift(row).flatMap(_.lift(colIndex(colName)))
+  def get(colName: String): Option[Vector[String]] =
+    scala.util.Try(apply(colName)).toOption
+  def get(row: Int, col: Int): Option[String] =
+    data.lift(row).flatMap(_.lift(col))
+
+  def updated(row: Int, col: Int, newValue: String): Grid =
+    copy(data = data.updated(row, data(row).updated(col, newValue)))
+
+  def updated(row: Int, colName: String, newValue: String): Grid =
+    updated(row, colIndex(colName), newValue)
+
+  def isDistinct(colNames: String*): Boolean =
+    colNames.forall { c =>
+      val values = apply(c); values.distinct == values
+    }
+
+  def toNestedMap(keyColName: String)(
+      valueColNames: String*
+  ): Map[String, RowMap] =
+    data.indices.map { r =>
+      val key = apply(r)(keyColName)
+      val mapOfValues: RowMap = {
+        val values = valueColNames.map(c => apply(r)(c))
+        valueColNames.zip(values).toMap
+      }
+      key -> mapOfValues
+    }.toMap
+
+  def filter(colName: String)(p: String => Boolean): Grid =
+    copy(data = data.filter(row => p(row(colIndex(colName)))))
+
+  def lookUp(colName: String)(rowValueInCol: String): Grid =
+    filter(colName)(_ == rowValueInCol)
+
+  def filterRow(p: RowMap => Boolean): Grid =
+    copy(data =
+      (for (i <- data.indices if p(rowMap(i))) yield data(i)).toVector
+    )
+
+  def sorted(colName: String = headings(0)): Grid =
+    copy(data = data.sortBy(row => row.lift(colIndex(colName)).getOrElse("")))
+
+  def sortBy[T: Ordering](f: Row => T): Grid = copy(data = data.sortBy(f))
+
+  def updateCol(colName: String)(f: RowMap => String): Grid =
+    Grid(
+      headings,
+      data.indices
+        .map(r => data(r).updated(colIndex(colName), f(rowMap(r))))
+        .toVector
+    )
+
+  def updateHeadings(f: String => String): Grid =
+    copy(headings = headings.map(f))
+
+  def updateValues(f: String => String): Grid =
+    copy(data = data.map(xs => xs.map(f)))
+
+  def mapRows[T](f: RowMap => T): Vector[T] =
+    data.indices.map(r => f(rowMap(r))).toVector
+
+  def mapHeadings[T](f: String => T): Vector[T] = headings.map(f).toVector
+
+  def mapValues[T](f: String => T): Vector[Vector[T]] =
+    data.map(xs => xs.map(f))
+
+  def sumIntCol(colName: String): Int =
+    apply(colName).map(_.toIntOption.getOrElse(0)).sum
+
+  def sumDoubleCol(colName: String): Double =
+    apply(colName).map(_.toDoubleOption.getOrElse(0.0)).sum
+
+  def addCol(colName: String)(f: RowMap => String): Grid =
+    Grid(
+      headings :+ colName,
+      data.indices.map(i => data(i) :+ f(rowMap(i))).toVector
+    )
+
+  def addCol(colName: String, col: Col): Grid =
+    Grid(headings :+ colName, data.indices.map(i => data(i) :+ col(i)).toVector)
+
+  def addEmptyCols(colNames: String*): Grid =
+    Grid(
+      headings ++ colNames,
+      data.indices.map(i => data(i) ++ Vector.fill(colNames.size)("")).toVector
+    )
+
+  def keep(colNames: String*): Grid = {
+    val heads = colNames.toVector
+    Grid(heads, data.indices.map(i => heads.map(c => apply(i)(c))).toVector)
+  }
+
+  def skip(colNames: String*): Grid = {
+    val heads = headings diff colNames
+    Grid(heads, data.indices.map(i => heads.map(c => apply(i)(c))).toVector)
+  }
+
+  def join(colNameInThis: String, colNameInThat: String)(that: Grid): Grid = {
+    val extraHeadings = (that.headings diff Seq(colNameInThat)) diff headings
+    val thatMap = that.toNestedMap(colNameInThat)(extraHeadings*)
+    var result = this
+    extraHeadings.foreach { colName =>
+      result = result.addCol(colName) { rm =>
+        val key = rm(colNameInThis)
+        thatMap(key)(colName)
+      }
+    }
+    result
+  }
+
+  def appendIntersecting(that: Grid): Grid =
+    val common = headings intersect that.headings
+    Grid(
+      headings = common,
+      data = keep(common*).data ++ that.keep(common*).data
+    )
+
+  def find(p: RowMap => Boolean): Option[RowMap] =
+    data.indices.map(rowMap).find(p)
+  def indexOf(p: RowMap => Boolean): Int = data.indices.map(rowMap).indexOf(p)
+  def count(p: RowMap => Boolean): Int = data.indices.map(rowMap).count(p)
+
+  def rename(colNamePairs: (String, String)*): Grid =
+    val renameMap = colNamePairs.toMap
+    copy(headings = headings.map(h => renameMap.getOrElse(h, h)))
+
+  def values: Map[String, Col] = headings.map(h => (h, apply(h).distinct)).toMap
+
+  def replaceBy(colName: String)(f: String => String): Grid =
+    val i = colIndex(colName)
+    copy(data = data.map(r => r.updated(i, f(r(i)))))
+
+  def trim: Grid = copy(headings.map(_.trim), data.map(r => r.map(_.trim)))
+
+  // TODO: IS THIS REALLY NEEDED WHEN ASSERTED THAT EQUAL COL LENGTHS ???
+  lazy val maxLengths: Vector[Int] =
+    headings.map(h => (apply(h).map(_.size) :+ h.size).max)
+
+  lazy val maxLengthOf: Map[String, Int] = (headings zip maxLengths).toMap
+
+  lazy val showHeadings: String =
+    headings.map(h => h + (" " * (maxLengthOf(h) - h.size))).mkString("|")
+
+  lazy val hline: String =
+    (defaultHeadingShowSep.toString * showHeadings.size) + "\n"
+
+  def padToMax(row: Int, pad: String = " ")(colName: String): String =
+    apply(row)(colName) + (pad * (maxLengthOf(colName) - apply(row)(
+      colName
+    ).size))
+
+  lazy val showData: String =
+    data.indices
+      .map(r =>
+        headings.map(h => padToMax(r)(h)).mkString(defaultColShowSep.toString)
+      )
+      .toVector
+      .mkString("\n")
+
+  lazy val show: String =
+    s"$hline$showHeadings\n$hline$showData" // \n$hline  dim = (nRows, nCols) = ($nRows, $nCols)"
+
+  /** Pretty-printing suitable for use in REPL. * */
+  def pp: Unit = println(show)
+
+  /** Trimmed pretty-printing suitable for use in REPL. * */
+  def pp(maxWidth: Int): Unit =
+    println(show.split('\n').map(_.take(maxWidth)).mkString("\n"))
+
+  def toText(delim: Char = defaultDelim): String =
+    headings.mkString("", delim.toString, "\n") +
+      data.map(_.mkString("", delim.toString, "\n")).mkString

--- a/src/main/scala/timeEdit/Date.scala
+++ b/src/main/scala/timeEdit/Date.scala
@@ -1,0 +1,56 @@
+package kaptenallocweb.timeEdit
+
+case class Date(year: Int, month: Int, dayOfMonth: Int = 1)
+    extends Ordered[Date]:
+
+  def compare(that: Date): Int =
+    import math.Ordered.orderingToOrdered
+    (year, month, dayOfMonth) compare (that.year, that.month, that.dayOfMonth)
+
+  lazy val shortDate = s"$dayOfMonth/$month"
+  lazy val longDate = f"$year%04d-$month%02d-$dayOfMonth%02d"
+  def show = longDate
+
+  lazy val monthName: String = Date.monthName(month - 1)
+
+object Date:
+
+  def apply(s: String): Date =
+    val xs = s.split('-')
+    require(
+      xs.length == 3 && xs(0).length == 4 &&
+        xs.map(_.toIntOption).forall(_.isDefined),
+      s"Illegal date YYYY-MM-DD: $s"
+    )
+    new Date(xs(0).toInt, xs(1).toInt, xs(2).toInt)
+
+  val dayOfWeekNumberToName: Map[Int, String] = Map(
+    1 -> "sön",
+    2 -> "mån",
+    3 -> "tis",
+    4 -> "ons",
+    5 -> "tor",
+    6 -> "fre",
+    7 -> "lör"
+  )
+  val weekDays: Map[String, Int] = Map(
+    "mån" -> 0,
+    "tis" -> 1,
+    "ons" -> 2,
+    "tor" -> 3,
+    "fre" -> 4
+  )
+  val monthName = Vector(
+    "jan",
+    "feb",
+    "mar",
+    "apr",
+    "maj",
+    "jun",
+    "jul",
+    "aug",
+    "sep",
+    "okt",
+    "nov",
+    "dec"
+  )

--- a/src/main/scala/timeEdit/TimeEdit.scala
+++ b/src/main/scala/timeEdit/TimeEdit.scala
@@ -1,0 +1,173 @@
+package kaptenallocweb.timeEdit
+
+import org.scalajs.dom.{XMLHttpRequest}
+import kaptenallocweb.tabby.Grid
+
+object TimeEdit:
+
+    def fetchData(
+        onLoad: (xhr: XMLHttpRequest) => Unit,
+        onError: (xhr: XMLHttpRequest) => Unit,
+        uri: String =
+          "https://cloud.timeedit.net/lu/web/lth1/ri19566250000YQQ28Z0507007y9Y4763gQ0g5X6Y65ZQ176.csv"
+    ) =
+      val xhr = XMLHttpRequest()
+      xhr.open(
+        "GET",
+        uri
+      )
+      xhr.onload = _ => onLoad(xhr)
+      xhr.onerror = _ => onError(xhr)
+      xhr.send()
+    
+    def findDiscrepancies(timeEditData: String, kaptenAllocData: Seq[String]) =
+        val timeEditGrid = timeEditData.split('\n').toVector.toScheduleGrid
+        val kaptenAllocGrid = 
+            Grid
+                .fromLines(
+                    kaptenAllocData.toVector.filterNot(_.startsWith("---")),
+                    '|'
+                )
+                .trim
+        
+        val timeEditNormalized = normalizeTimeEditData(timeEditGrid)
+        val kaptenAllocNormalized = normalizeKaptenAllocData(kaptenAllocGrid)
+
+        val discrepancies = collection.mutable.Set[String]()
+
+        kaptenAllocNormalized.filterNot(_.rum.startsWith("Ambulans")).foreach {
+            kaEntry => 
+                timeEditNormalized.find(teEntry =>
+                    teEntry.datum == kaEntry.datum &&
+                    teEntry.start == kaEntry.start &&
+                    teEntry.del   == kaEntry.del   &&
+                    teEntry.typ   == kaEntry.typ   &&
+                    teEntry.grupp == kaEntry.grupp
+                ) match {
+                    case Some(matchedEntry) =>
+                        if (matchedEntry.rum != kaEntry.rum) then
+                            discrepancies.add(
+                                s"Saländring för ${kaEntry.datum} ${kaEntry.start} ${kaEntry.del} ${kaEntry.typ} ${kaEntry.grupp} - Ny sal: ${matchedEntry.rum}"
+                            ) 
+                    case None => 
+                        discrepancies.add(
+                            s"Saknas i TimeEdit: ${kaEntry.datum} ${kaEntry.start} ${kaEntry.del} ${kaEntry.typ} ${kaEntry.grupp} ${kaEntry.rum}"
+                        )
+                }
+        }
+
+        discrepancies.toSet
+    
+    private case class NormalizedEntry(
+        datum: String,
+        del: String,
+        typ: String,
+        grupp: String,
+        rum: String,
+        start: String
+    )
+
+    private def normalizeTimeEditData(grid: Grid): Vector[NormalizedEntry] =
+        grid.data.flatMap { row =>
+            val datum = row(grid.colIndex("datum"))
+            val start = row(grid.colIndex("start"))
+            val del = row(grid.colIndex("del"))
+            val typ = row(grid.colIndex("typ"))
+            val lokal = row(grid.colIndex("lokal"))
+            val grupp = row(grid.colIndex("grupp"))
+
+            val rooms = lokal.split(",").map(_.trim.stripPrefix("E:"))
+            val groups = grupp.split(",").map(_.trim)
+
+            rooms.zip(groups).map { case (room, group) =>
+                NormalizedEntry(datum, del, typ, group, room, start)
+            }
+        }
+
+    private def normalizeKaptenAllocData(grid: Grid): Vector[NormalizedEntry] =
+        grid.data.map { row =>
+            val datum = row(grid.colIndex("datum"))
+            val kl = row(grid.colIndex("kl"))
+            val del = row(grid.colIndex("del"))
+            val typ = row(grid.colIndex("typ"))
+            val grupp = row(grid.colIndex("grupp"))
+            val rum = row(grid.colIndex("rum"))
+
+            val adjustedTime = adjustTimeBy15Minutes(kl, -15)
+
+            NormalizedEntry(datum, del, typ, grupp, rum, adjustedTime)
+        }
+    
+    private def adjustTimeBy15Minutes(time: String, minutesDelta: Int): String =
+        val parts = time.split(":")
+        if (parts.length != 2) return time
+
+        try {
+            val hours = parts(0).toInt
+            val minutes = parts(1).toInt
+            val totalMinutes = hours * 60 + minutes + minutesDelta
+            val newHours = (totalMinutes / 60) % 24
+            val newMinutes = totalMinutes % 60
+
+            f"$newHours%02d:$newMinutes%02d"
+        } catch {
+            case _: Exception => time
+        }
+
+extension (lines: Vector[String])
+  def toScheduleGrid: Grid =
+    val xsUnpatched = lines.drop(3).map(removeQuotesAndCommasInsideQuotes)
+    val g = Grid
+      .fromLines(xsUnpatched, ',')
+      .trim
+      .updateHeadings(_.toLowerCase.filter(_.isLetterOrDigit))
+      .trim
+      .updateValues(addCommasIfSpaceSep)
+
+    val newHeads = Seq(
+      "startdatum" -> "datum",
+      "starttid" -> "start",
+      "märkning" -> "del",
+      "undervisningstyp" -> "typ",
+      "lokallokaldelplatskommentar" -> "lokal",
+      "studentgrupp" -> "grupp"
+    )
+
+    val selectTyp = Set("Resurstid", "Labb")
+
+    g.keep(newHeads.map(_._1)*)
+      .rename(newHeads*)
+      .filter("del")(_.nonEmpty)
+      .updateCol("del") { rm =>
+        if rm("del").trim.toLowerCase.startsWith("prog") then "Prog" else "Dod"
+      }
+      .filter("typ")(selectTyp.contains)
+      .updateCol("typ") { rm =>
+        if rm("del") == "Dod" then "DodLabb"
+        else
+          rm("typ") match
+            case "Resurstid" => "Resurstid"
+            case "Labb"      => "ProgLabb"
+      }
+      .filter("datum")(d =>
+        Date(d) <= Date(s"2025-10-19") && Date(
+          d
+        ) >= Date(s"2025-09-01")
+      )
+
+end extension
+
+private def removeQuotesAndCommasInsideQuotes(s: String): String =
+  var isInsideQuotes = false
+  var i = 0
+  val result = StringBuilder()
+  while i < s.length do
+    if s(i) == '"' then isInsideQuotes = !isInsideQuotes
+    else if isInsideQuotes && s(i) == ',' then result ++= " "
+    else result += s(i)
+    i += 1
+  end while
+  result.toString
+
+private def addCommasIfSpaceSep(s: String): String =
+  s.split(" ").filter(_.nonEmpty).mkString(",")


### PR DESCRIPTION
This PR adds functionality for comparing TimeEdit data with the hardcoded kapten alloc data on page load, which allows us to detect changed rooms or cancelled bookings.

<img width="1113" height="620" alt="image" src="https://github.com/user-attachments/assets/89f3c049-3945-441d-b097-770bff777eb1" />

General diffs:
- Added Tabby by copying its source code and stripping Java dependencies (to allow for ScalaJS compatability)
- Created TimeEdit object which exposes methods for fetching CSV data and comparing it with Kapten Alloc data
- Render UI elements based on results of fetch and found diffs