### PR TITLE
Use semantic HTML elements for schedule table

### DIFF
--- a/index-dev.html
+++ b/index-dev.html
@@ -29,16 +29,19 @@
         margin-right: 20px;
       }
 
-       td, th {
-        padding-right: 10px;
+      td, th {
+        padding: 2px 5px;
+        border-right: 1px solid black;
+        border-left: 1px solid black;
+        text-align: left;
       }
 
       table {
         border-collapse: collapse;
+        border: 1px solid black;
       }
 
       th {
-        text-align: left;
         border-bottom: 1px solid black;
       }
 

--- a/index-dev.html
+++ b/index-dev.html
@@ -29,6 +29,11 @@
         margin-right: 20px;
       }
 
+      td, th {
+        padding-right: 20px;
+        text-align: left;
+      }
+
       #akademiskKvart, #todayCheckBox {
         width: 20px;
         height: 20px;

--- a/index-dev.html
+++ b/index-dev.html
@@ -29,9 +29,17 @@
         margin-right: 20px;
       }
 
-      td, th {
-        padding-right: 20px;
+       td, th {
+        padding-right: 10px;
+      }
+
+      table {
+        border-collapse: collapse;
+      }
+
+      th {
         text-align: left;
+        border-bottom: 1px solid black;
       }
 
       #akademiskKvart, #todayCheckBox {

--- a/index.html
+++ b/index.html
@@ -30,8 +30,16 @@
       }
 
       td, th {
-        padding-right: 20px;
+        padding-right: 10px;
+      }
+
+      table {
+        border-collapse: collapse;
+      }
+
+      th {
         text-align: left;
+        border-bottom: 1px solid black;
       }
 
       #akademiskKvart, #todayCheckBox {

--- a/index.html
+++ b/index.html
@@ -29,6 +29,11 @@
         margin-right: 20px;
       }
 
+      td, th {
+        padding-right: 20px;
+        text-align: left;
+      }
+
       #akademiskKvart, #todayCheckBox {
         width: 20px;
         height: 20px;

--- a/index.html
+++ b/index.html
@@ -30,15 +30,18 @@
       }
 
       td, th {
-        padding-right: 10px;
+        padding: 2px 5px;
+        border-right: 1px solid black;
+        border-left: 1px solid black;
+        text-align: left;
       }
 
       table {
         border-collapse: collapse;
+        border: 1px solid black;
       }
 
       th {
-        text-align: left;
         border-bottom: 1px solid black;
       }
 


### PR DESCRIPTION
Prior to this PR, the schedule table has been rendered as a formatted string inside a single `<pre>` element. While that works, it limits our ability to style individual parts or table components, and the spacing/formatting must be handled within the string. One thing we might want to do in the future is to make a subtle background color shift to every other table row, or perhaps mark certain entries in a certain way. 

In this PR, we instead generate an HTML `<table>` element, populate it with `<tr>` (table row) elements, and populate those with `<td>` (table data cell) elements. While it might make the rendering logic slightly more complex, this is a very standard approach and additionally comes with the benefit of better browser compatability. This is because native HTML table elements are semantic and universally supported, allowing browsers to apply appropriate default styling, handle text reflow and wrapping automatically, and ensure proper accessibility features (like screen reader support) work out of the box.

Here's what the `<table>` looks like in action:

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/0654f5a3-22c4-4be3-920b-02bf433d38e5" />

I decided to remove the manual `|` separators from the string data. If we want lines between each cell, we can add this through CSS, which would result in something like this:

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/66e80874-454b-4832-a168-5942b13b9385" />

Please let me know if you have any thoughts or concerns!