### PR TITLE
Use KaptenAllocData class, move non-UI logic out of main

### DIFF
--- a/src/main/scala/KaptenAllocData.scala
+++ b/src/main/scala/KaptenAllocData.scala
@@ -1,13 +1,55 @@
 package kaptenallocweb
 
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
 case class KaptenAllocData(
     course: String,
     date: String,
-    week: Option[String],
+    week: String,
     day: String,
     time: String,
-    `type`: String,
+    entryType: String,
     group: String,
     room: String,
     supervisor: String
 )
+
+extension (s: String)
+  def containsAll(xs: Array[String], isCaseSensitive: Boolean = true): Boolean =
+    val xs2 = if isCaseSensitive then xs else xs.map(_.toLowerCase)
+    val s2 = if isCaseSensitive then s else s.toLowerCase
+    xs2.forall(x => s2.contains(x))
+
+val MagicRegisterPaymentWord = "lön"
+
+extension (rows: Seq[KaptenAllocData])
+  def filterRows(words: Array[String]): Seq[KaptenAllocData] =
+    if words.lift(0) != Some(MagicRegisterPaymentWord) then
+      rows.filter(entry => {
+        val searchString = s"${entry.course}|${entry.date}|${entry.day}|${entry.time}|${entry.entryType}|${entry.group}|${entry.room}|${entry.supervisor}"
+        searchString.containsAll(words)
+      })
+    else
+      val paymentRows = rows.groupBy(_.supervisor).toSeq.sortBy(_._1).map(_._2).flatten
+      def timeToPeriod(hrs: String): String =
+        val start = hrs.take(2)
+        val end = start.toIntOption.map(_ + 2).getOrElse("??")
+        s"$start-$end"
+
+      paymentRows.filter(entry => {
+        val searchString = s"${entry.supervisor};${entry.course};${entry.date};${timeToPeriod(entry.time)}"
+        searchString.containsAll(words.drop(1))
+      })
+
+  def akademiskKvart(isAkademiskKvart: Boolean): Seq[KaptenAllocData] =
+    if isAkademiskKvart then rows
+    else rows.map(entry => entry.copy(time = entry.time.replace(":15", ":00")))
+
+  def filterOnlyToday(filterOnToday: Boolean): Seq[KaptenAllocData] =
+    def todayString: String =
+      val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+      LocalDate.now().format(formatter)
+
+    if !filterOnToday then rows
+    else rows.filter(entry => entry.date == todayString)

--- a/src/main/scala/data-GENERATED.scala
+++ b/src/main/scala/data-GENERATED.scala
@@ -1,5 +1,8 @@
 package kaptenallocweb
-val dataGeneratedFromKaptenAlloc: Seq[String] = """
+
+import kaptenallocweb.utils.getWeekNumber
+
+val dataGeneratedFromKaptenAlloc: Seq[KaptenAllocData] = """
 -------------------------------------------------------------
 del |datum     |dag|kl   |typ      |grupp|rum     |handledare
 -------------------------------------------------------------
@@ -430,4 +433,18 @@ Prog|2025-10-17|fre|15:15|ProgLabb |XA1  |Ambulans|ALW
 Prog|2025-10-17|fre|15:15|ProgLabb |XA2  |Ambulans|NAK       
 Prog|2025-10-17|fre|15:15|ProgLabb |XA3  |Ambulans|JUG       
 Prog|2025-10-17|fre|15:15|ProgLabb |XA4  |Ambulans|WIS       
-""".trim.split('\n').toSeq
+""".trim.split('\n').drop(3).map(line =>
+  val parts = line.split('|').map(_.trim)
+  KaptenAllocData(
+    course = parts(0),
+    date = parts(1),
+    week = getWeekNumber(parts(1)).toString,
+    time = parts(3),
+    day = parts(2),
+    entryType = parts(4),
+    group = parts(5),
+    room = parts(6),
+    supervisor = parts(7)
+    )
+  )
+

--- a/src/main/scala/utils/downloadIcs.scala
+++ b/src/main/scala/utils/downloadIcs.scala
@@ -1,0 +1,15 @@
+package kaptenallocweb.utils
+
+import org.scalajs.dom
+import org.scalajs.dom.document
+
+// TODO: Give name to file based on if room, group or any field always are the same
+/** Creates an ICS file with given content and presents it as a download to the user */
+def downloadIcs(content: String, fileName: String = "handledartider.ics"): Unit =
+  val file = new dom.Blob(scala.scalajs.js.Array(content), new dom.BlobPropertyBag { `type` = "text/calendar" })
+  val a = document.createElement("a").asInstanceOf[dom.html.Anchor]
+  val url = dom.URL.createObjectURL(file)
+  a.setAttribute("download", fileName)
+  a.href = url
+  a.click()
+  a.remove()

--- a/src/main/scala/utils/getDayOfWeek.scala
+++ b/src/main/scala/utils/getDayOfWeek.scala
@@ -1,0 +1,21 @@
+package kaptenallocweb.utils
+
+import java.time.LocalDate
+
+/** Takes date in format YYYY-MM-DD and returns Swedish 3-letter day abbreviation */
+def getDayOfWeek(date: String): String =
+  try {
+    val parsedDate = LocalDate.parse(date)
+    parsedDate.getDayOfWeek.toString.toLowerCase.capitalize match {
+      case "Monday" => "mån"
+      case "Tuesday" => "tis"
+      case "Wednesday" => "ons"
+      case "Thursday" => "tor"
+      case "Friday" => "fre"
+      case "Saturday" => "lör"
+      case "Sunday" => "sön"
+      case _ => "okänd"
+    }
+  } catch {
+    case _: Exception => "okänd"
+  }

--- a/src/main/scala/utils/getWeekNumber.scala
+++ b/src/main/scala/utils/getWeekNumber.scala
@@ -1,0 +1,14 @@
+package kaptenallocweb.utils
+
+import java.time.LocalDate
+import java.time.temporal.WeekFields
+
+/** Takes date in format YYYY-MM-DD */
+def getWeekNumber(date: String): Int =
+  val values = date.split("-").map(_.toInt)
+  // Get week number using the ISO-8601 definition, where a week starts on Monday and the first week has a minimum of 4 days
+  val week = LocalDate.of(values(0), values(1), values(2)).get(WeekFields.ISO.weekOfYear)
+  if week == 0 then
+    LocalDate.of(values(0) - 1, 12, 31).get(WeekFields.ISO.weekOfYear)
+  else
+    week


### PR DESCRIPTION
This PR is a pretty big refactor which makes issue #1 significantly easier. This is what is being changed:

- **Consistent usage of `KaptenAllocData` class** - Prior to this PR, this class was barely in use, and kapten alloc entries were sometimes represented as raw strings, or an array of its substrings. Now, the generated large string data (`data-GENERATED.scala`) is immediately parsed to `KaptenAllocData` instances. This makes filtering and other related functionality cleaner, and also sets it as the standard representation for entries within the source code. The `TimeEdit.scala` module has been updated to also parse the TimeEdit CSV data into `KaptenAllocData` instances. This is why #1 will be easy to implement, as the data is represented by the same data structures.
- **Moved extension-methods to appropriate files** - Most extension methods were for filtering the `String`-based kapten alloc entries. Since they now operate on a `Seq[KaptenAllocData]` instead, they have been moved to `KaptenAllocData.scala` instead.
- **Utility folder for utility functions** - Pure functions, such as `getDayOfWeek` and `getWeekNumber` have been moved to their own modules within the `utils` subdirectory together with the procedure function `downloadIcs`. This reduces the clutter in `main.scala`, which now **only contains the `@main` startup procedure and UI-related functions**.
